### PR TITLE
updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/jclem/path-proxy/issues"
   },
   "dependencies": {
-    "inflection": "~1.3.0"
+    "inflection": "^1.7.1"
   },
   "devDependencies": {
-    "jasmine-node": "~1.11.0"
+    "jasmine-node": "^1.14.5"
   }
 }


### PR DESCRIPTION
the main reason for this is so the inflection version can be the same as it is in `heroku-client`
